### PR TITLE
coordenadasGraficarVectores

### DIFF
--- a/campoElectrico.m
+++ b/campoElectrico.m
@@ -1,4 +1,4 @@
-
+% Cálculo vectorial de campo eléctrico por partícula
 function [campoElectricoX,campoElectricoY] = campoElectrico(vCoordenadas, vCargas, particulaCampo, n)
 
 % Constante k

--- a/electrodos.m
+++ b/electrodos.m
@@ -53,19 +53,53 @@ n = length(vCoordenadas);
 %}
 
 % Prueba compleja
-
 % Agregrar unidades
-vCoordenadas = [[2,1;2,2;2,3;2,4;2,5;2,6;2,7;2,8;2,9;2,10;2,11];...
-               [4,1;4,2;4,3;4,4;4,5;4,6;4,7;4,8;4,9;4,10;4,11]];
+vCoordenadas = [[2,1;
+                 2,2;
+                 2,3];
+               
+               [4,1;
+                4,2;
+                4,3;]];
+            
 % Agregrar unidades
-vCargas = [[1.6022e-9;1.6022e-19;1.6022e-19;1.6022e-9;1.6022e-9;...
-            1.6022e-9;1.6022e-9;1.6022e-9;1.6022e-9;1.6022e-9;1.6022e-9],...
-           [-1.6022e-9;-1.6022e-9;-1.6022e-9;-1.6022e-9;-1.6022e-9;
-            -1.6022e-9;-1.6022e-9;-1.6022e-9;-1.6022e-9;-1.6022e-9;-1.6022e-9]];
+vCargas = [1.6022e-9;1.6022e-9;1.6022e-9;
+           -1.6022e-9;-1.6022e-9;-1.6022e-9;];
 
 % Cantidad de partículas        
 n = length(vCoordenadas);
-        
+
+
+% Partícula en donde se halla/cualcula el campo eléctrico
+
+% Preguntar si se Calcula para Particula de Prueba o Particula Existente
+particulaPrueba = input("Particula existente (E) o de prueba (P): ", "s");
+
+if particulaPrueba == "P"
+    
+    % Coordenada partícula de prueba en donde se calcula Campo Eléctrico
+    coordenadaCampoX = input("Coordenada X: ");
+    coordenadaCampoY = input("Coordenada Y: ");
+    
+    % Almacenamiento de coordenadas de particula prueba
+    % en arreglo de coordenadas de partpículas existentes
+    vCoordenadas(end + 1, 1) = coordenadaCampoX;
+    vCoordenadas(end, 2) = coordenadaCampoY;
+    
+    % Añadir carga de prueba a vector de cargas
+    vCargas(end + 1, 1) = 1;
+    
+    % Aumentar número de partículas/ se agrega la de prueba
+    n = n + 1;
+    
+    % Partícula en que se evalua el campo es la última en el arreglo
+    % Posición n
+    particulaCampo = n;
+else
+    % Particula en dodne se calculará el campo eléctrico
+    particulaCampo = input("Particula a calcular campo E: ");
+end
+
         
 % Plot de las coordenadas de las partículas en 2D según la carga
 for i = 1:n
@@ -79,22 +113,22 @@ for i = 1:n
        hold on
    end
 end
-axis([-5 12 -5 12]) % Limita ejes del plot
+axis equal  % Limita ejes del plot
+% PRUEBA DE EJES: axis([-5 12 -5 12])
 
-
-% Partícula en donde se halla/cualcula el campo eléctrico
-% ¿Pordía tal vez cambiarse partícula por coordenadas en donde se busca
-% calcular el campo eléctrico?
-particulaCampo = input("Particula a calcular campo E: ");
 
 % Función campo Eléctrico
 [campoElectricoX,campoElectricoY] = campoElectrico(vCoordenadas, vCargas, particulaCampo, n);
 
-% Plot vectores campo eléctrico en la partícula
+
+% Graficación vectores campo eléctrico en la partícula
+
+% Creación de matriz repitiendo coordenada X - Y en donde inicia el vector
 xp = repmat(vCoordenadas(particulaCampo,1), 1, n);
 yp = repmat(vCoordenadas(particulaCampo,2), 1, n);
-quiver(xp, yp, campoElectricoX, campoElectricoY); hold on
 
-% Claculo magnitud de cmapo eléctrico
+graficoVectores(xp, yp, campoElectricoX, campoElectricoY);
+
+% Calculo magnitud de campo eléctrico
 magnitudCampoE = ((sum(campoElectricoX))^2 + ...
                   (sum(campoElectricoY))^2)^(1/2);

--- a/graficoVectores.m
+++ b/graficoVectores.m
@@ -1,0 +1,87 @@
+% Graficación de vectores de campo eléctrico
+
+function graficoVectores(xp, yp, campoElectricoX, campoElectricoY)
+
+% Cambio vectores filas a vectores columnas en Matriz Repetida
+xp = xp(:);
+yp = yp(:);
+
+% Cambio vectores filas a vectores columnas en matrices de campoElectricoXY 
+campoXCol = campoElectricoX(:);
+campoYCol = campoElectricoY(:);
+
+% Creación de tabla de campoElectrico en X - Y
+tablaCampoXY = table(campoXCol, campoYCol);
+
+
+%{ 
+La graficación de vectores se divide en 2 partes
+
+1. Vectores Únicos
+2. Vectores Repetidos
+
+Esto se realizo para poder cambiar su COLOR y TAMAÑO de manera que
+se puedan DISTINGUIR vectores de IGUAL MANGITUD Y DIRECCIÓN
+y que esto NO se SOLAPEN aparentando que estos Vecotres Repetidos
+no se graficaron.
+%} 
+
+
+% Graficación Vectores Campo eléctrico Únicos
+
+% Documentación de unique
+%{
+[C,ia,ic] = unique(___) also returns index vectors ia and ic using any 
+of the previous syntaxes.
+
+If A is a table or timetable, then unique returns the unique rows in A 
+in sorted order. For timetables, unique takes row times and row values
+ into account when determining whether rows are unique, and 
+sorts the output timetable C by row times.
+
+If A is a vector, then C = A(ia) and A = C(ic).
+
+PUEDE BORRARSE AL FINAL
+%}
+
+% Hallar valores X, Y, únicos (NO se repiten)
+[tablaUnicos, ~, ic] = unique(tablaCampoXY);
+
+% Cantidad de valores X-Y de campo Eléctrico Únicos
+cantUnicos = length(tablaUnicos.campoXCol);
+
+% Plot de Vectores únicos
+quiver(xp(1:cantUnicos), yp(1:cantUnicos), ...
+       tablaUnicos.campoXCol, tablaUnicos.campoYCol,...
+       'color', '#ffc000');
+       hold on
+
+  
+% Graficación Vectores campo Eléctrico Repetidos
+
+% Contar valores que se repiten 
+contarReps = accumarray(ic,1);
+
+%{
+Para DISTINGUIR y poder OBSERVAR los VECTORES REPETIDOS,
+se cambiara su TAMAÑO APARENTE en la GRAFICA, de manera que
+se VERAN MÁS GRANDES, de lo que en verdad son.
+%}
+
+k = 0.92; % Factor de Tamaño de Vector
+for i = 1:cantUnicos
+   if contarReps(i) > 1
+       % Para cada VECTOR REPETIDO
+       for r = 1:contarReps(i)-1
+           % Plot de Vectores Repetidos
+            quiver(xp(1), yp(1), tablaUnicos.campoXCol(i), tablaUnicos.campoYCol(i), ...
+                  k, 'color', '#77AC30'); hold on
+       
+            k = k + 0.01;   % Se aumenta el factor de tamaño del vector
+       end
+   end
+end  
+
+axis equal % Ajuste nuevo de ejes según vectores /// ¿seguro que es necesario? Verificar
+
+end


### PR DESCRIPTION
Simplificación del código principal separando el código que gráfica los vectores en su propia función aparte en archivo graficoVectores.m .  Se agregó la opción de calcular el campo eléctrico por una carga de prueba en cualquier posición del plano;  además se corrigió error por el cual vectores de misma magnitud y dirección se solapan y se mostraban como un solo, impidiendo identificar la existencia de dos o más vectores iguales.