### PR TITLE
pruebasCorreciones

### DIFF
--- a/electrodos.m
+++ b/electrodos.m
@@ -16,65 +16,19 @@
 clc
 clear
 
+% 1. Ingresar/Cargar Coordenadas y Carga eléctrica de cada partícula
 
-%Ingresar cantidad, coordenadas, y carga para cada partícula
-%{
-n = input("Num. partículas: "); % Número de partículas
-
-% Matriz/Vector Almacenar Coordenadas/Carga eléctrica por Partícula
-vCoordenadas = zeros(n,2);   [[x1, y1], [x2, y2], [x3, y3]];
-vCargas = 1:n;
-
-for c = 1:1:n
-      % Coordenadas de particulas
-      x = input("x: ");  %Unidades???
-      y = input("y: ");
-      vCoordenadas(c,:) = [x, y];
-
-      % Carga eléctrica de partículas
-      carga = input("Carga: ");
-      vCargas(c) = carga;
-
-      % Gráficar partículas
-      plot(x, y, '.r')
-      hold on
-end
-%}
+prueba = input("Tipo de prueba: ");
+[n, vCoordenadas, vCargas] = tipoPrueba(prueba);
 
 
-% Directamente crear coordenadas y cargas eléctricas
-% Prueba simple
-%{ 
-vCoordenadas = [1,2; -2,3; 7,10; 4, 8];
-vCargas = [-5 * 10^-9, 7 * 10^-9, 12 * 10 ^ -9, -7 * 10^-9];
-n = length(vCoordenadas);
-%}
-
-
-% Prueba
-
-vCoordenadas = [[2,1,0;
-                 2,2,0;
-                 2,3,0];
-               
-               [4,1,0;
-                4,2,0;
-                4,3,0;]]; % Agregrar unidades
-
-vCargas = [1.6022e-9;1.6022e-9;1.6022e-9;
-           -1.6022e-9;-1.6022e-9;-1.6022e-9;]; % Agregrar unidades
-
-% Cantidad de partículas        
-n = length(vCoordenadas);
-
-% Dimension
-dimension = 2;
+% 2. Calculos y gráficos de campo Eléctrico
 
 % Preguntar si se Calcula para Particula de Prueba o Particula Existente
 particulaPrueba = input("Particula existente (E) o de prueba (P): ", "s");
 
 % Coordenadas en donde se halla/cualcula el campo eléctrico de partícual de prueba
-if particulaPrueba == "P"
+if particulaPrueba == "P" || particulaPrueba == "p"
     % Coordenada partícula de prueba en donde se calcula Campo Eléctrico
     coordenadaCampoX = input("Coordenada X: ");
     coordenadaCampoY = input("Coordenada Y: ");
@@ -84,7 +38,7 @@ if particulaPrueba == "P"
     vCoordenadas(end, 2) = coordenadaCampoY;
     
     % Añadir carga de prueba a vector de cargas q = 1
-    vCargas(end + 1, 1) = 1;
+    vCargas(end + 1) = 1;
     
     % Aumentar número de partículas/ se agrega la de prueba
     n = n + 1;
@@ -98,11 +52,11 @@ end
 
 
 % Graficación de partículas
-graficoCoordenadas(vCoordenadas, vCargas, n, dimension)
+graficoCoordenadas(vCoordenadas, vCargas, n, 2)
 
 
 % Calculo vectorial campo Eléctrico (X, Y)
-[campoElectricoX,campoElectricoY, ~] = campoElectrico(vCoordenadas, vCargas, particulaCampo, n);
+[campoElectricoX,campoElectricoY, campoElectricoZ] = campoElectrico(vCoordenadas, vCargas, particulaCampo, n);
 
 
 % Graficación vectores campo eléctrico en la partícula
@@ -116,12 +70,14 @@ graficoVectores(xp, yp, campoElectricoX, campoElectricoY);
 
 
 % Calculo magnitud de campo eléctrico
-magnitudCampoE = ((sum(campoElectricoX))^2 + ...
-                  (sum(campoElectricoY))^2)^(1/2);
+[magnitudCampoE, Ex_num, Ey_num, ~] = magnitudCampo(campoElectricoX, campoElectricoY, campoElectricoZ);
               
 disp("Magnitud campo eléctrico en (" + ...
     vCoordenadas(particulaCampo,1) + ", " + vCoordenadas(particulaCampo,2) ...
     + "): " + magnitudCampoE) % Agregar unidades?
+
+% Vector resultante graficado
+quiver(xp(1), yp(1), Ex_num, Ey_num, 'color', 'k')
 
 
 
@@ -130,31 +86,21 @@ disp("Magnitud campo eléctrico en (" + ...
 %% 3D
 
 clc
+clear
 
-% Prueba
+% 1. Cargar Coordenadas y Carga eléctrica de cada partícula
 
-vCoordenadas = [[2,2,1;
-                 2,2,2;
-                 2,2,3];
-               
-               [4,4,1;
-                4,4,2;
-                4,4,3;]]; % Agregrar unidades
-            
-vCargas = [1.6022e-9;1.6022e-9;1.6022e-9;
-           -1.6022e-9;-1.6022e-9;-1.6022e-9;]; % Agregrar unidades
+prueba = input("Tipo de prueba: ");
+[n, vCoordenadas, vCargas] = tipoPrueba3(prueba);
 
-% Cantidad de partículas        
-n = length(vCoordenadas);
 
-% Dimension
-dimension = 3;
+% 2. Calcular y gráficar campo eléctrico
 
 % Preguntar si se Calcula para Particula de Prueba o Particula Existente
 particulaPrueba = input("Particula existente (E) o de prueba (P): ", "s");
 
 % Coordenadas en donde se halla/cualcula el campo eléctrico de partícual de prueba
-if particulaPrueba == "P"
+if particulaPrueba == "P" || particulaPrueba == "p"
     % Coordenada partícula de prueba en donde se calcula Campo Eléctrico
     coordenadaCampoX = input("Coordenada X: ");
     coordenadaCampoY = input("Coordenada Y: ");
@@ -166,7 +112,7 @@ if particulaPrueba == "P"
     vCoordenadas(end, 3) = coordenadaCampoZ;
     
     % Añadir carga de prueba a vector de cargas q = 1
-    vCargas(end + 1, 1) = 1;
+    vCargas(end + 1) = 1;
     
     % Aumentar número de partículas / se agrega la partícula de prueba
     n = n + 1;
@@ -180,7 +126,7 @@ end
 
 
 % Graficación de partículas
-graficoCoordenadas(vCoordenadas, vCargas, n, dimension)
+graficoCoordenadas(vCoordenadas, vCargas, n, 3)
 
 
 % Calculo vectorial campo Eléctrico (X, Y, Z)
@@ -199,13 +145,14 @@ graficoVectores3(xp, yp, zp, campoElectricoX, campoElectricoY, campoElectricoZ);
 
 
 % Calculo magnitud de campo eléctrico
-magnitudCampoE = ((sum(campoElectricoX))^2  + ...
-                  (sum(campoElectricoY))^2  + ...
-                  (sum(campoElectricoZ))^2) ^ (1/2);
+[magnitudCampoE, Ex_num, Ey_num, Ez_num] = magnitudCampo(campoElectricoX, campoElectricoY, campoElectricoZ);
 
 disp("Magnitud campo eléctrico en (" + ...
     vCoordenadas(particulaCampo,1) + ", " + vCoordenadas(particulaCampo,2) + ", " + vCoordenadas(particulaCampo, 3) ...
     + "): " + magnitudCampoE) % Agregar unidades?
+
+% Vector resultante graficado
+quiver3(xp(1), yp(1), zp(1), Ex_num, Ey_num, Ez_num, 'color', 'k')
 
 
 

--- a/graficoVectores3.m
+++ b/graficoVectores3.m
@@ -73,7 +73,7 @@ se cambiara su TAMAÑO APARENTE en la GRAFICA, de manera que
 se VERAN MÁS GRANDES, de lo que en verdad son.
 %}
 
-k = 0.92; % Factor de Tamaño de Vector
+t = 0.92; % Factor de Tamaño de Vector
 for i = 1:cantUnicos
    if contarReps(i) > 1
        % Para cada VECTOR REPETIDO
@@ -81,9 +81,9 @@ for i = 1:cantUnicos
            % Plot de Vectores Repetidos
             quiver3(xp(1), yp(1), zp(1), ...
                     tablaUnicos.campoXCol(i), tablaUnicos.campoYCol(i), tablaUnicos.campoZCol(i),...
-                    k, 'color', '#77AC30'); hold on
+                    t, 'color', '#77AC30'); hold on
        
-            k = k + 0.01;   % Se aumenta el factor de tamaño del vector
+            t = t + 0.01;   % Se aumenta el factor de tamaño del vector
 
        end
    end

--- a/magnitudCampo.m
+++ b/magnitudCampo.m
@@ -1,0 +1,26 @@
+function [magnitudCampoE, Ex_num, Ey_num, Ez_num] = magnitudCampo(campoElectricoX,campoElectricoY, campoElectricoZ)
+%MAGNITUDCAMPO Calculo de magnitud del campo eléctrico
+%   Uitlizando variables simbólicas, se calcula la sumatoria del campo
+%   eléctrico en cada una de las componentes de dirección (XYZ) 
+%   generado por cada una de las partículas que ya existen, 
+%   sobre la carga de prueba o existente en que se calcula el campo.
+
+% Definir variables simbólicas (Para calculos con mayor precisión)
+syms x y z;
+
+% Calcular simbólicamnete la sumatoria del campo eléctrico por componentes
+Ex = sum(campoElectricoX.*x);
+Ey = sum(campoElectricoY.*y);
+Ez = sum(campoElectricoZ.*z);
+
+% Devolver vector resultante como número y no variable simbolica
+Ex_num = double(subs(Ex, [x y z], [1 1 1]));
+Ey_num = double(subs(Ey, [x y z], [1 1 1]));
+Ez_num = double(subs(Ez, [x y z], [1 1 1]));
+
+% Calcular magnitud de campo eléctrico
+E = (Ex^2 + Ey^2 + Ez^2)^(1/2);
+
+% Covertir magnitud simbólica a dato tipo double que sea manipulable
+magnitudCampoE = double(subs(E, [x y z], [1 1 1]));
+end

--- a/tipoPrueba.m
+++ b/tipoPrueba.m
@@ -1,0 +1,71 @@
+function [n, vCoordenadas, vCargas] = tipoPrueba(prueba)
+%TIPOPRUEBA Prueba de cargas para calcular el campo eléctrico en 2D
+%   Según el valor ingresado de tipo de prueba (Un número entero)
+%   se realizara algún tipo de test, es decir, se colocaran cargas
+%   en ciertas coordenadas y se preguntará donde se quiere calcular
+%   el campo eléctrico. (Se irán agregando pruebas)
+
+if prueba == 1
+    % 1.1 Ingresar cantidad, coordenadas, y carga para cada partícula
+
+    n = input("Num. partículas: "); % Número de partículas
+
+    % Matriz/Vector Almacenar Coordenadas/Carga eléctrica por Partícula
+    vCoordenadas = zeros(n,3);   % [[x1, y1], [x2, y2], [x3, y3]];
+    vCargas = 1:n;
+
+    for c = 1:1:n
+          % Coordenadas de particulas
+          x = input("x: ");  %Unidades???
+          y = input("y: ");
+          vCoordenadas(c,:) = [x, y, 0];
+
+          % Carga eléctrica de partículas
+          carga = input("Carga: ");
+          vCargas(c) = carga;
+
+          % Gráficar partículas
+          plot(x, y, '.r')
+          hold on
+    end
+
+
+elseif prueba == 2
+    % 1.2 Directamente crear coordenadas y cargas eléctricas
+    % 1.21 Prueba simple
+
+    vCoordenadas = [1,2,0; -2,3,0; 7,10,0; 4, 8,0];
+    vCargas = [-5 * 10^-9, 7 * 10^-9, 12 * 10 ^ -9, -7 * 10^-9];
+    % Cantidad de partículas
+    n = length(vCoordenadas);
+
+
+elseif prueba == 3
+    % 1.22 Prueba barra 2D
+
+    % Matriz Coordenadas (2D --> ∀ z, z = 0)
+    vCoordenadas = [[2,1,0;
+                     2,2,0;
+                     2,3,0];
+
+                   [4,1,0;
+                    4,2,0;
+                    4,3,0;]]; % Agregrar unidades
+
+    % Vector Columna de cargas eléctricas
+    vCargas = [1.6022e-9;1.6022e-9;1.6022e-9;
+               -1.6022e-9;-1.6022e-9;-1.6022e-9;]; % Agregrar unidades
+
+    % Cantidad de partículas        
+    n = length(vCoordenadas);
+    
+    
+else
+    disp("Actualmente solo hay 3 pruebas escriba '1', '2', '3'")
+    prueba = input("Tipo de prueba: ");
+    [n, vCoordenadas, vCargas] = tipoPrueba(prueba);
+    
+
+end
+end
+

--- a/tipoPrueba3.m
+++ b/tipoPrueba3.m
@@ -1,0 +1,82 @@
+function [n, vCoordenadas, vCargas] = tipoPrueba3(prueba)
+%TIPOPRUEBA3 Prueba de cargas para calcular el campo eléctrico en 3D
+%   Según el valor ingresado de tipo de prueba (Un número entero)
+%   se realizara algún tipo de test, es decir, se colocaran cargas
+%   en ciertas coordenadas y se preguntará donde se quiere calcular
+%   el campo eléctrico. (Se irán agregando pruebas)
+
+if prueba == 1
+    % 1.1 Prueba barra
+
+
+    vCoordenadas = [[2,2,1;
+                     2,2,2;
+                     2,2,3];
+
+                   [4,4,1;
+                    4,4,2;
+                    4,4,3;]]; % Agregrar unidades
+
+    vCargas = [1.6022e-9;1.6022e-9;1.6022e-9;
+               -1.6022e-9;-1.6022e-9;-1.6022e-9;]; % Agregrar unidades
+
+    % Cantidad de partículas        
+    n = length(vCoordenadas);    
+    
+    
+elseif prueba == 2
+    % 1.12 Prueba anillo simple
+
+    clc
+    clear
+
+    vCoordenadas = [0 0 2.5; 1.5 0 1.5; 2.5 0 0; 1.5 0 -1.5; 0 0 -2.5; -1.5 0 -1.5; -2.5 0 0; -1.5 0 1.5];
+
+    % Cantidad de partículas        
+    n = length(vCoordenadas);
+
+    % Cargas según cantidad
+    vCargas = repmat(1.6022e-9, 1, n);    
+    
+    
+elseif prueba == 3
+    % 1.13 Prueba anillo/circunferencia compleja
+
+    % Parámetros de circunferencia
+    radio = 3;
+    centro = [0, 0];
+    cant_puntos = 50;
+
+    % Coordenadas de la circunferencia
+    theta1 = linspace(0, pi, cant_puntos/2)';
+    x1 = radio * cos(theta1);
+    z1 = radio * sin(theta1);
+    coordenadas1 = [x1, zeros(size(x1)), z1] + [centro, 0];
+
+    theta2 = linspace(pi, 2*pi, cant_puntos/2)';
+    x2 = radio * cos(theta2);
+    z2 = radio * sin(theta2);
+    coordenadas2 = [x2, zeros(size(x2)), z2] + [centro, 0];
+
+    vCoordenadas = [coordenadas1; coordenadas2];
+
+    % coords(round(num_points/2),:) = [];
+
+    % Graficar círculo
+    % plot3(coords(:,1), coords(:,2), coords(:,3), 'p', 'LineWidth', 2);
+
+    % Cantidad de partículas        
+    n = length(vCoordenadas);
+
+    % Cargas según cantidad
+    vCargas = repmat(1.6022e-9, 1, n);
+
+    
+else
+    disp("Actualmente solo hay 3 pruebas escriba '1', '2', '3'")
+    prueba = input("Tipo de prueba: ");
+    [n, vCoordenadas, vCargas] = tipoPrueba3(prueba);
+    
+end
+end
+


### PR DESCRIPTION
Se añadieron pruebas en 3D de anillos para calcular el campo eléctrico y se separaron estas pruebas en funciones para cada una de las dimensiones (2D/3D). Se corrigió un error por el cuál los cálculos con números flotantes daban número imprescisos, la solución consiste en realizar los cálculos con variables simbólicas.